### PR TITLE
Add PoC for post previews in list template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,6 +13,9 @@
                 </div>
                 <div class="date-time-title post">
                     <a href="{{ .Permalink }}">{{ .Title }}</a>
+                    <div class="post-preview">
+                        <p>{{ .Summary }}</p>
+                    </div>
                 </div>
             </div>
             {{ end }}


### PR DESCRIPTION
Solves #3.

Needs more work in terms of style and implementation, but the PoC serves
to see what it could look like.

I need to think more about how to properly split the post preview, and
make it look a little better by making the preview text not stand out as
much as the title.
Some sort of faded color of what the background is might work? Maybe
look at the Material style guidelines?